### PR TITLE
Ability to initialize Aegis manuall

### DIFF
--- a/AegisBuild.mk
+++ b/AegisBuild.mk
@@ -91,3 +91,13 @@ build-local: \
 	init-container-push-photon-local \
 	init-container-bundle-photon-fips \
 	init-container-push-photon-fips-local
+
+build-essentials-local: \
+	safe-bundle-ist \
+	safe-push-ist-local \
+	sidecar-bundle-ist \
+	sidecar-push-ist-local \
+	sentinel-bundle-ist \
+	sentinel-push-ist-local \
+	init-container-bundle-ist \
+	init-container-push-ist-local \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #
 
 # The common version tag assigned to all the things.
-VERSION=0.17.4
+VERSION=0.18.0
 
 # Utils
 include ./AegisMacOs.mk

--- a/app/safe/internal/bootstrap/k8s.go
+++ b/app/safe/internal/bootstrap/k8s.go
@@ -60,7 +60,7 @@ func persistKeys(privateKey, publicKey, aesSeed string) error {
 		return errors.Wrap(err, "Error creating the secret")
 	}
 
-	state.SetAgeKey(keysCombined)
+	state.SetMasterKey(keysCombined)
 
 	return nil
 }

--- a/app/safe/internal/server/handle/handle.go
+++ b/app/safe/internal/server/handle/handle.go
@@ -49,6 +49,17 @@ func InitializeRoutes() {
 			return
 		}
 
+		// Route to define the master key when AEGIS_MANUAL_KEY_INPUT is set.
+		// Only Aegis Sentinel is allowed to call this API endpoint.
+		// This method works only once. Once a key is set, there is no way to
+		// update it. You will have to kill the Aegis Sentinel pod and restart it
+		// to be able to set a new key.
+		if r.Method == http.MethodPost && p == "/sentinel/v1/keys" {
+			log.DebugLn(&cid, "Handler: will receive keys")
+			route.ReceiveKeys(cid, w, r, sid)
+			return
+		}
+
 		// Route to add secrets to Aegis Safe.
 		// Only Aegis Sentinel is allowed to call this API endpoint.
 		// Calling it from anywhere else will error out.

--- a/app/safe/internal/server/handle/handle.go
+++ b/app/safe/internal/server/handle/handle.go
@@ -49,7 +49,7 @@ func InitializeRoutes() {
 			return
 		}
 
-		// Route to define the master key when AEGIS_MANUAL_KEY_INPUT is set.
+		// Route to define the master key when AEGIS_SAFE_MANUAL_KEY_INPUT is set.
 		// Only Aegis Sentinel is allowed to call this API endpoint.
 		// This method works only once. Once a key is set, there is no way to
 		// update it. You will have to kill the Aegis Sentinel pod and restart it

--- a/app/safe/internal/server/route/delete.go
+++ b/app/safe/internal/server/route/delete.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shieldworks/aegis/core/audit"
 	entity "github.com/shieldworks/aegis/core/entity/data/v1"
 	reqres "github.com/shieldworks/aegis/core/entity/reqres/safe/v1"
+	"github.com/shieldworks/aegis/core/env"
 	"github.com/shieldworks/aegis/core/log"
 	"github.com/shieldworks/aegis/core/validation"
 	"io"
@@ -40,6 +41,11 @@ func isSentinel(j audit.JournalEntry, cid string, w http.ResponseWriter, svid st
 }
 
 func Delete(cid string, w http.ResponseWriter, r *http.Request, svid string) {
+	if env.SafeManualKeyInput() && !state.MasterKeySet() {
+		log.InfoLn(&cid, "Delete: Master key not set")
+		return
+	}
+
 	j := audit.JournalEntry{
 		CorrelationId: cid,
 		Entity:        reqres.SecretDeleteRequest{},

--- a/app/safe/internal/server/route/fetch.go
+++ b/app/safe/internal/server/route/fetch.go
@@ -24,6 +24,11 @@ import (
 )
 
 func Fetch(cid string, w http.ResponseWriter, r *http.Request, svid string) {
+	if env.SafeManualKeyInput() && !state.MasterKeySet() {
+		log.InfoLn(&cid, "Fetch: Master key not set")
+		return
+	}
+
 	j := audit.JournalEntry{
 		CorrelationId: cid,
 		Entity:        reqres.SecretFetchRequest{},

--- a/app/safe/internal/server/route/list.go
+++ b/app/safe/internal/server/route/list.go
@@ -21,6 +21,11 @@ import (
 )
 
 func List(cid string, w http.ResponseWriter, r *http.Request, svid string) {
+	if env.SafeManualKeyInput() && !state.MasterKeySet() {
+		log.InfoLn(&cid, "List: Master key not set")
+		return
+	}
+
 	j := audit.JournalEntry{
 		CorrelationId: cid,
 		Entity:        reqres.SecretListRequest{},

--- a/app/safe/internal/server/route/receive.go
+++ b/app/safe/internal/server/route/receive.go
@@ -1,0 +1,61 @@
+/*
+ * .-'_.---._'-.
+ * ||####|(__)||   Protect your secrets, protect your business.
+ *   \\()|##//       Secure your sensitive data with Aegis.
+ *    \\ |#//                    <aegis.ist>
+ *     .\_/.
+ */
+
+package route
+
+import (
+	"github.com/shieldworks/aegis/app/safe/internal/state"
+	"github.com/shieldworks/aegis/core/audit"
+	"github.com/shieldworks/aegis/core/env"
+	"github.com/shieldworks/aegis/core/log"
+	"net/http"
+)
+
+func ReceiveKeys(cid string, w http.ResponseWriter, r *http.Request, svid string) {
+	if env.SafeManualKeyInput() && !state.MasterKeySet() {
+		log.InfoLn(&cid, "Receive: Master key not set")
+		return
+	}
+
+	j := createDefaultJournalEntry(cid, svid, r)
+	audit.Log(j)
+
+	if !isSentinel(j, cid, w, svid) {
+		j.Event = audit.EventBadSvid
+		audit.Log(j)
+		return
+	}
+
+	log.DebugLn(&cid, "ReceiveKeys: sentinel svid:", svid)
+
+	body := readBody(cid, r, w, j)
+	if body == nil {
+		j.Event = audit.EventBadPayload
+		audit.Log(j)
+		return
+	}
+
+	ur := unmarshalKeyInputRequest(cid, body, j, w)
+	if ur == nil {
+		j.Event = audit.EventBadPayload
+		audit.Log(j)
+		return
+	}
+
+	sr := *ur
+
+	j.Entity = sr
+
+	aesCipherKey := sr.AesCipherKey
+	agePrivateKey := sr.AgeSecretKey
+	agePublicKey := sr.AgePublicKey
+
+	keysCombined := agePrivateKey + "\n" + agePublicKey + "\n" + aesCipherKey
+
+	state.SetMasterKey(keysCombined)
+}

--- a/app/safe/internal/state/io-age.go
+++ b/app/safe/internal/state/io-age.go
@@ -11,11 +11,11 @@ package state
 import "strings"
 
 func ageKeyTriplet() (string, string, string) {
-	if ageKey == "" {
+	if masterKey == "" {
 		return "", "", ""
 	}
 
-	parts := strings.Split(ageKey, "\n")
+	parts := strings.Split(masterKey, "\n")
 
 	if len(parts) != 3 {
 		return "", "", ""

--- a/app/safe/internal/state/io-encrypt.go
+++ b/app/safe/internal/state/io-encrypt.go
@@ -21,6 +21,11 @@ import (
 
 func encryptToWriterAge(out io.Writer, data string) error {
 	_, publicKey, _ := ageKeyTriplet()
+
+	if publicKey == "" {
+		return errors.New("encryptToWriterAge: no public key")
+	}
+
 	recipient, err := age.ParseX25519Recipient(publicKey)
 	if err != nil {
 		return errors.Wrap(err, "encryptToWriterAge: failed to parse public key")
@@ -48,6 +53,11 @@ func encryptToWriterAge(out io.Writer, data string) error {
 
 func encryptToWriterAes(out io.Writer, data string) error {
 	_, _, aesKey := ageKeyTriplet()
+
+	if aesKey == "" {
+		return errors.New("encryptToWriter: no AES key")
+	}
+
 	aesKeyDecoded, err := hex.DecodeString(aesKey)
 	if err != nil {
 		return errors.Wrap(err, "encryptToWriter: failed to decode AES key")

--- a/app/safe/internal/state/io-persist.go
+++ b/app/safe/internal/state/io-persist.go
@@ -41,6 +41,10 @@ func saveSecretToDisk(secret entity.SecretStored, dataPath string) error {
 		}
 	}()
 
+	if env.SafeFipsCompliant() {
+		return encryptToWriterAes(file, string(data))
+	}
+
 	return encryptToWriterAge(file, string(data))
 }
 

--- a/app/sentinel/cmd/main.go
+++ b/app/sentinel/cmd/main.go
@@ -51,6 +51,13 @@ func parseNamespace(parser *argparse.Parser) *string {
 	})
 }
 
+func parseInputKeys(parser *argparse.Parser) *string {
+	return parser.String("i", "input-keys", &argparse.Options{
+		Required: false,
+		Help:     "A string containing the private and public Age keys and AES seed, each separated by '\\n'.",
+	})
+}
+
 func parseBackingStore(parser *argparse.Parser) *string {
 	return parser.String("b", "store", &argparse.Options{
 		Required: false,
@@ -119,7 +126,7 @@ func printSecretNeeded() {
 
 func doPost(workload *string, secret *string, namespace *string,
 	backingStore *string, useKubernetes *bool, template *string, format *string,
-	encrypt *bool, deleteSecret *bool, appendSecret *bool,
+	encrypt *bool, deleteSecret *bool, appendSecret *bool, inputKeys *string,
 ) {
 	workloadP := ""
 	if workload != nil {
@@ -171,9 +178,14 @@ func doPost(workload *string, secret *string, namespace *string,
 		appendP = *appendSecret
 	}
 
+	inputKeysP := ""
+	if inputKeys != nil {
+		inputKeysP = *inputKeys
+	}
+
 	safe.Post(
 		workloadP, secretP, namespaceP, backingStoreP, useK8sP,
-		templateP, formatP, encryptP, deleteP, appendP,
+		templateP, formatP, encryptP, deleteP, appendP, inputKeysP,
 	)
 }
 
@@ -185,6 +197,7 @@ func main() {
 	deleteSecret := parseDeleteSecret(parser)
 	appendSecret := parseAppendSecret(parser)
 	namespace := parseNamespace(parser)
+	inputKeys := parseInputKeys(parser)
 	backingStore := parseBackingStore(parser)
 	workload := parseWorkload(parser)
 	secret := parseSecret(parser)
@@ -218,6 +231,12 @@ func main() {
 		*namespace = "default"
 	}
 
+	if inputKeys == nil || *inputKeys == "" {
+		*inputKeys = ""
+	}
+
 	doPost(workload, secret, namespace, backingStore,
-		useKubernetes, template, format, encrypt, deleteSecret, appendSecret)
+		useKubernetes, template, format, encrypt, deleteSecret, appendSecret,
+		inputKeys,
+	)
 }

--- a/app/sentinel/internal/safe/post.go
+++ b/app/sentinel/internal/safe/post.go
@@ -192,7 +192,6 @@ func Post(workloadId, secret, namespace, backingStore string, useKubernetes bool
 		}
 
 		parts := strings.Split(inputKeys, "\n")
-
 		if len(parts) != 3 {
 			printPayloadError(errors.New("post: Bad data! Very bad data"))
 			return

--- a/core/entity/reqres/safe/v1/v1.go
+++ b/core/entity/reqres/safe/v1/v1.go
@@ -25,6 +25,12 @@ type SecretUpsertRequest struct {
 	Err           string            `json:"err,omitempty"`
 }
 
+type KeyInputRequest struct {
+	AgeSecretKey string `json:"ageSecretKey"`
+	AgePublicKey string `json:"agePublicKey"`
+	AesCipherKey string `json:"aesCipherKey"`
+}
+
 type SecretUpsertResponse struct {
 	Err string `json:"err,omitempty"`
 }

--- a/core/env/safe.go
+++ b/core/env/safe.go
@@ -184,6 +184,21 @@ func SafeSecretBackupCount() int {
 	return l
 }
 
+// SafeManualKeyInput returns a boolean indicating whether to use manual
+// cryptographic key input for Aegis Safe, instead of letting it bootstrap
+// automatically. If the environment variable is not set or its value is
+// not "true", the function returns false. Otherwise, the function returns true.
+func SafeManualKeyInput() bool {
+	p := os.Getenv("AEGIS_SAFE_MANUAL_KEY_INPUT")
+	if p == "" {
+		return false
+	}
+	if strings.ToLower(p) == "true" {
+		return true
+	}
+	return false
+}
+
 // SafeDataPath returns the path to the safe data directory.
 // The path is determined by the AEGIS_SAFE_DATA_PATH environment variable.
 // If the environment variable is not set, the default path "/data" is returned.
@@ -196,11 +211,11 @@ func SafeDataPath() string {
 }
 
 // SafeAgeKeyPath returns the path to the safe age key directory.
-// The path is determined by the AEGIS_SAFE_AGE_KEY_PATH environment variable.
+// The path is determined by the AEGIS_CRYPTO_KEY_PATH environment variable.
 // If the environment variable is not set, the default path "/key/key.txt"
 // is returned.
 func SafeAgeKeyPath() string {
-	p := os.Getenv("AEGIS_SAFE_AGE_KEY_PATH")
+	p := os.Getenv("AEGIS_CRYPTO_KEY_PATH")
 	if p == "" {
 		p = "/key/key.txt"
 	}
@@ -226,10 +241,10 @@ func SafeBootstrapTimeout() time.Duration {
 
 // SafeAgeKeySecretName returns the name of the environment variable that holds
 // the Aegis Safe age key. The value is retrieved using the
-// "AEGIS_SAFE_AGE_KEY_SECRET_NAME" environment variable. If this variable is
+// "AEGIS_CRYPTO_KEY_NAME" environment variable. If this variable is
 // not set or is empty, the default value "aegis-safe-age-key" is returned.
 func SafeAgeKeySecretName() string {
-	p := os.Getenv("AEGIS_SAFE_AGE_KEY_SECRET_NAME")
+	p := os.Getenv("AEGIS_CRYPTO_KEY_NAME")
 	if p == "" {
 		p = "aegis-safe-age-key"
 	}

--- a/dockerfiles/aegis-ist-fips/init-container.Dockerfile
+++ b/dockerfiles/aegis-ist-fips/init-container.Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto GOOS=linux go build -mod vendor -a -
 FROM gcr.io/distroless/static-debian11
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-ist-fips/safe.Dockerfile
+++ b/dockerfiles/aegis-ist-fips/safe.Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto GOOS=linux go build -mod vendor -a -
 FROM gcr.io/distroless/static-debian11
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis-safe"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-ist-fips/sentinel.Dockerfile
+++ b/dockerfiles/aegis-ist-fips/sentinel.Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto GOOS=linux go build -mod vendor -a -
 FROM gcr.io/distroless/static-debian11
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis-sentinel"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-ist-fips/sidecar.Dockerfile
+++ b/dockerfiles/aegis-ist-fips/sidecar.Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto GOOS=linux go build -mod vendor -a -
 FROM gcr.io/distroless/static-debian11
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-ist/init-container.Dockerfile
+++ b/dockerfiles/aegis-ist/init-container.Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o aegis-init-container \
 FROM gcr.io/distroless/static-debian11
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-ist/safe.Dockerfile
+++ b/dockerfiles/aegis-ist/safe.Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o aegis-safe ./app/safe/cm
 FROM gcr.io/distroless/static-debian11
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis-safe"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-ist/sentinel.Dockerfile
+++ b/dockerfiles/aegis-ist/sentinel.Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o sloth ./app/sentinel/bus
 FROM gcr.io/distroless/static-debian11
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis-sentinel"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-ist/sidecar.Dockerfile
+++ b/dockerfiles/aegis-ist/sidecar.Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o aegis-sidecar ./app/side
 FROM gcr.io/distroless/static-debian11
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-photon-fips/init-container.Dockerfile
+++ b/dockerfiles/aegis-photon-fips/init-container.Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto GOOS=linux go build -mod vendor -a -
 FROM photon:5.0
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-photon-fips/safe.Dockerfile
+++ b/dockerfiles/aegis-photon-fips/safe.Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto GOOS=linux go build -mod vendor -a -
 FROM photon:5.0
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis-safe"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-photon-fips/sentinel.Dockerfile
+++ b/dockerfiles/aegis-photon-fips/sentinel.Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto GOOS=linux go build -mod vendor -a -
 FROM photon:5.0
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis-sentinel"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-photon-fips/sidecar.Dockerfile
+++ b/dockerfiles/aegis-photon-fips/sidecar.Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto GOOS=linux go build -mod vendor -a -
 FROM photon:5.0
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-photon/init-container.Dockerfile
+++ b/dockerfiles/aegis-photon/init-container.Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o aegis-init-container \
 FROM photon:5.0
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-photon/safe.Dockerfile
+++ b/dockerfiles/aegis-photon/safe.Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o aegis-safe ./app/safe/cm
 FROM photon:5.0
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis-safe"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-photon/sentinel.Dockerfile
+++ b/dockerfiles/aegis-photon/sentinel.Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o sloth ./app/sentinel/bus
 FROM photon:5.0
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis-sentinel"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/aegis-photon/sidecar.Dockerfile
+++ b/dockerfiles/aegis-photon/sidecar.Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o aegis-sidecar ./app/side
 FROM photon:5.0
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/example/init-container.Dockerfile
+++ b/dockerfiles/example/init-container.Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o example \
 FROM gcr.io/distroless/static-debian11
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/example/multiple-secrets.Dockerfile
+++ b/dockerfiles/example/multiple-secrets.Dockerfile
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o sloth \
 FROM gcr.io/distroless/static-debian11
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/example/sdk.Dockerfile
+++ b/dockerfiles/example/sdk.Dockerfile
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o env \
 FROM gcr.io/distroless/static-debian11
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/dockerfiles/example/sidecar.Dockerfile
+++ b/dockerfiles/example/sidecar.Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o env \
 FROM gcr.io/distroless/static-debian11
 
 LABEL "maintainers"="Volkan Özçelik <volkan@aegis.ist>"
-LABEL "version"="0.17.4"
+LABEL "version"="0.18.0"
 LABEL "website"="https://aegis.ist/"
 LABEL "repo"="https://github.com/shieldworks/aegis"
 LABEL "documentation"="https://aegis.ist/docs/"

--- a/examples/aegis-workshop/init-container/Deployment.yaml
+++ b/examples/aegis-workshop/init-container/Deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: example
       containers:
       - name: main
-        image: aegishub/example-using-init-container:0.17.4
+        image: aegishub/example-using-init-container:0.18.0
         env:
         - name: SECRET
           valueFrom:
@@ -48,7 +48,7 @@ spec:
       # See `./register.sh` to register the workload and finalize
       # this init container.
       - name: init-container
-        image: aegishub/aegis-ist-init-container:0.17.4
+        image: aegishub/aegis-ist-init-container:0.18.0
         volumeMounts:
         # Volume mount for SPIRE unix domain socket.
         - name: spire-agent-socket

--- a/examples/aegis-workshop/init-container/image-override.yaml
+++ b/examples/aegis-workshop/init-container/image-override.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: localhost:5000/example-using-init-container:0.17.4
+        image: localhost:5000/example-using-init-container:0.18.0
       initContainers:
       - name: init-container
-        image: localhost:5000/aegis-ist-init-container:0.17.4
+        image: localhost:5000/aegis-ist-init-container:0.18.0

--- a/examples/aegis-workshop/inspector/Deployment.yaml
+++ b/examples/aegis-workshop/inspector/Deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: aegis-inspector
       containers:
       - name: main
-        image: aegishub/example-multiple-secrets:0.17.4
+        image: aegishub/example-multiple-secrets:0.18.0
         volumeMounts:
         # Volume mount for SPIRE unix domain socket.
         - name: spire-agent-socket

--- a/examples/aegis-workshop/inspector/image-override.yaml
+++ b/examples/aegis-workshop/inspector/image-override.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: localhost:5000/example-multiple-secrets:0.17.4
+        image: localhost:5000/example-multiple-secrets:0.18.0
         env:
           - name: AEGIS_LOG_LEVEL
             value: "0"

--- a/examples/aegis-workshop/sdk/Deployment.yaml
+++ b/examples/aegis-workshop/sdk/Deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: example
       containers:
       - name: main
-        image: aegishub/example-using-sdk:0.17.4
+        image: aegishub/example-using-sdk:0.18.0
         volumeMounts:
         # Volume mount for SPIRE unix domain socket.
         - name: spire-agent-socket

--- a/examples/aegis-workshop/sdk/image-override.yaml
+++ b/examples/aegis-workshop/sdk/image-override.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
       - name: main
-        image: localhost:5000/example-using-sdk:0.17.4
+        image: localhost:5000/example-using-sdk:0.18.0

--- a/examples/aegis-workshop/sidecar/Deployment.yaml
+++ b/examples/aegis-workshop/sidecar/Deployment.yaml
@@ -26,13 +26,13 @@ spec:
       serviceAccountName: example
       containers:
       - name: main
-        image: aegishub/example-using-sidecar:0.17.4
+        image: aegishub/example-using-sidecar:0.18.0
         volumeMounts:
         # `main` shares this volume with `sidecar`.
         - mountPath: /opt/aegis
           name: aegis-secrets-volume
       - name: sidecar
-        image: aegishub/aegis-ist-sidecar:0.17.4
+        image: aegishub/aegis-ist-sidecar:0.18.0
         volumeMounts:
         # /opt/aegis/secrets.json is the place the secrets will be at.
         - mountPath: /opt/aegis

--- a/examples/aegis-workshop/sidecar/image-override.yaml
+++ b/examples/aegis-workshop/sidecar/image-override.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: main
-        image: localhost:5000/example-using-sidecar:0.17.4
+        image: localhost:5000/example-using-sidecar:0.18.0
       - name: sidecar
-        image: localhost:5000/aegis-ist-sidecar:0.17.4
+        image: localhost:5000/aegis-ist-sidecar:0.18.0

--- a/examples/multiple-secrets/k8s/Deployment.yaml
+++ b/examples/multiple-secrets/k8s/Deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: example
       containers:
       - name: main
-        image: aegishub/example-multiple-secrets:0.17.4
+        image: aegishub/example-multiple-secrets:0.18.0
         volumeMounts:
         # Volume mount for SPIRE unix domain socket.
         - name: spire-agent-socket

--- a/examples/multiple-secrets/k8s/image-override.yaml
+++ b/examples/multiple-secrets/k8s/image-override.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: localhost:5000/example-multiple-secrets:0.17.4
+        image: localhost:5000/example-multiple-secrets:0.18.0
         env:
         - name: AEGIS_LOG_LEVEL
           value: "0"

--- a/examples/using-init-container/k8s/Deployment.yaml
+++ b/examples/using-init-container/k8s/Deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: example
       containers:
       - name: main
-        image: aegishub/example-using-init-container:0.17.4
+        image: aegishub/example-using-init-container:0.18.0
         env:
         - name: SECRET
           valueFrom:
@@ -53,7 +53,7 @@ spec:
       # See `./register.sh` to register the workload and finalize
       # this init container.
       - name: init-container
-        image: aegishub/aegis-ist-init-container:0.17.4
+        image: aegishub/aegis-ist-init-container:0.18.0
         volumeMounts:
         # Volume mount for SPIRE unix domain socket.
         - name: spire-agent-socket

--- a/examples/using-init-container/k8s/image-override.yaml
+++ b/examples/using-init-container/k8s/image-override.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: localhost:5000/example-using-init-container:0.17.4
+        image: localhost:5000/example-using-init-container:0.18.0
       initContainers:
       - name: init-container
-        image: localhost:5000/aegis-ist-init-container:0.17.4
+        image: localhost:5000/aegis-ist-init-container:0.18.0

--- a/examples/using-sdk/k8s/Deployment.yaml
+++ b/examples/using-sdk/k8s/Deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: example
       containers:
       - name: main
-        image: aegishub/example-using-sdk:0.17.4
+        image: aegishub/example-using-sdk:0.18.0
         volumeMounts:
         # Volume mount for SPIRE unix domain socket.
         - name: spire-agent-socket

--- a/examples/using-sdk/k8s/image-override.yaml
+++ b/examples/using-sdk/k8s/image-override.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
       - name: main
-        image: localhost:5000/example-using-sdk:0.17.4
+        image: localhost:5000/example-using-sdk:0.18.0

--- a/examples/using-sidecar/k8s/Deployment.yaml
+++ b/examples/using-sidecar/k8s/Deployment.yaml
@@ -26,13 +26,13 @@ spec:
       serviceAccountName: example
       containers:
       - name: main
-        image: aegishub/example-using-sidecar:0.17.4
+        image: aegishub/example-using-sidecar:0.18.0
         volumeMounts:
         # `main` shares this volume with `sidecar`.
         - mountPath: /opt/aegis
           name: aegis-secrets-volume
       - name: sidecar
-        image: aegishub/aegis-ist-sidecar:0.17.4
+        image: aegishub/aegis-ist-sidecar:0.18.0
         volumeMounts:
         # /opt/aegis/secrets.json is the place the secrets will be at.
         - mountPath: /opt/aegis

--- a/examples/using-sidecar/k8s/image-override.yaml
+++ b/examples/using-sidecar/k8s/image-override.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: main
-        image: localhost:5000/example-using-sidecar:0.17.4
+        image: localhost:5000/example-using-sidecar:0.18.0
       - name: sidecar
-        image: localhost:5000/aegis-ist-sidecar:0.17.4
+        image: localhost:5000/aegis-ist-sidecar:0.18.0

--- a/hack/tag-docker.sh
+++ b/hack/tag-docker.sh
@@ -13,7 +13,7 @@
 # and we should not need to pull the images and sign them again.
 # So we’d rarely (if ever) need to use this script.
 
-VERSION="0.17.4"
+VERSION="0.18.0"
 
 export DOCKER_CONTENT_TRUST=0
 

--- a/k8s/safe/kustomizations/local/istanbul-fips/Deployment.yaml
+++ b/k8s/safe/kustomizations/local/istanbul-fips/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-safe
       containers:
         - name: main
-          image: aegishub/aegis-ist-safe:0.17.4
+          image: aegishub/aegis-ist-safe:0.18.0
           ports:
             - containerPort: 8443
           volumeMounts:
@@ -67,8 +67,8 @@ spec:
               value: "aegis-safe-age-key"
             - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
-            - name: AEGIS_MANUAL_KEY_INPUT
-              value: "true"
+            - name: AEGIS_SAFE_MANUAL_KEY_INPUT
+              value: "false"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/local/istanbul-fips/Deployment.yaml
+++ b/k8s/safe/kustomizations/local/istanbul-fips/Deployment.yaml
@@ -63,10 +63,12 @@ spec:
               value: "spiffe://aegis.ist/workload/aegis-safe/ns/aegis-system/sa/aegis-safe/n/"
             - name: AEGIS_SAFE_DATA_PATH
               value: "/data"
-            - name:  AEGIS_SAFE_AGE_KEY_SECRET_NAME
+            - name:  AEGIS_CRYPTO_KEY_NAME
               value: "aegis-safe-age-key"
-            - name: AEGIS_SAFE_AGE_KEY_PATH
+            - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
+            - name: AEGIS_MANUAL_KEY_INPUT
+              value: "true"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/local/istanbul-fips/image-override-ist-fips-local.yaml
+++ b/k8s/safe/kustomizations/local/istanbul-fips/image-override-ist-fips-local.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: localhost:5000/aegis-ist-fips-safe:0.17.4
+          image: localhost:5000/aegis-ist-fips-safe:0.18.0

--- a/k8s/safe/kustomizations/local/istanbul/Deployment.yaml
+++ b/k8s/safe/kustomizations/local/istanbul/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-safe
       containers:
         - name: main
-          image: aegishub/aegis-ist-safe:0.17.4
+          image: aegishub/aegis-ist-safe:0.18.0
           ports:
             - containerPort: 8443
           volumeMounts:
@@ -67,8 +67,8 @@ spec:
               value: "aegis-safe-age-key"
             - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
-            - name: AEGIS_MANUAL_KEY_INPUT
-              value: "true"
+            - name: AEGIS_SAFE_MANUAL_KEY_INPUT
+              value: "false"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/local/istanbul/Deployment.yaml
+++ b/k8s/safe/kustomizations/local/istanbul/Deployment.yaml
@@ -63,10 +63,12 @@ spec:
               value: "spiffe://aegis.ist/workload/aegis-safe/ns/aegis-system/sa/aegis-safe/n/"
             - name: AEGIS_SAFE_DATA_PATH
               value: "/data"
-            - name:  AEGIS_SAFE_AGE_KEY_SECRET_NAME
+            - name:  AEGIS_CRYPTO_KEY_NAME
               value: "aegis-safe-age-key"
-            - name: AEGIS_SAFE_AGE_KEY_PATH
+            - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
+            - name: AEGIS_MANUAL_KEY_INPUT
+              value: "true"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/local/istanbul/image-override-ist-local.yaml
+++ b/k8s/safe/kustomizations/local/istanbul/image-override-ist-local.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: localhost:5000/aegis-ist-safe:0.17.4
+          image: localhost:5000/aegis-ist-safe:0.18.0

--- a/k8s/safe/kustomizations/local/photon-fips/Deployment.yaml
+++ b/k8s/safe/kustomizations/local/photon-fips/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-safe
       containers:
         - name: main
-          image: aegishub/aegis-ist-safe:0.17.4
+          image: aegishub/aegis-ist-safe:0.18.0
           ports:
             - containerPort: 8443
           volumeMounts:
@@ -67,8 +67,8 @@ spec:
               value: "aegis-safe-age-key"
             - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
-            - name: AEGIS_MANUAL_KEY_INPUT
-              value: "true"
+            - name: AEGIS_SAFE_MANUAL_KEY_INPUT
+              value: "false"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/local/photon-fips/Deployment.yaml
+++ b/k8s/safe/kustomizations/local/photon-fips/Deployment.yaml
@@ -63,10 +63,12 @@ spec:
               value: "spiffe://aegis.ist/workload/aegis-safe/ns/aegis-system/sa/aegis-safe/n/"
             - name: AEGIS_SAFE_DATA_PATH
               value: "/data"
-            - name:  AEGIS_SAFE_AGE_KEY_SECRET_NAME
+            - name:  AEGIS_CRYPTO_KEY_NAME
               value: "aegis-safe-age-key"
-            - name: AEGIS_SAFE_AGE_KEY_PATH
+            - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
+            - name: AEGIS_MANUAL_KEY_INPUT
+              value: "true"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/local/photon-fips/image-override-photon-fips-local.yaml
+++ b/k8s/safe/kustomizations/local/photon-fips/image-override-photon-fips-local.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: localhost:5000/aegis-photon-fips-safe:0.17.4
+          image: localhost:5000/aegis-photon-fips-safe:0.18.0

--- a/k8s/safe/kustomizations/local/photon/Deployment.yaml
+++ b/k8s/safe/kustomizations/local/photon/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-safe
       containers:
         - name: main
-          image: aegishub/aegis-ist-safe:0.17.4
+          image: aegishub/aegis-ist-safe:0.18.0
           ports:
             - containerPort: 8443
           volumeMounts:
@@ -67,8 +67,8 @@ spec:
               value: "aegis-safe-age-key"
             - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
-            - name: AEGIS_MANUAL_KEY_INPUT
-              value: "true"
+            - name: AEGIS_SAFE_MANUAL_KEY_INPUT
+              value: "false"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/local/photon/Deployment.yaml
+++ b/k8s/safe/kustomizations/local/photon/Deployment.yaml
@@ -63,10 +63,12 @@ spec:
               value: "spiffe://aegis.ist/workload/aegis-safe/ns/aegis-system/sa/aegis-safe/n/"
             - name: AEGIS_SAFE_DATA_PATH
               value: "/data"
-            - name:  AEGIS_SAFE_AGE_KEY_SECRET_NAME
+            - name:  AEGIS_CRYPTO_KEY_NAME
               value: "aegis-safe-age-key"
-            - name: AEGIS_SAFE_AGE_KEY_PATH
+            - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
+            - name: AEGIS_MANUAL_KEY_INPUT
+              value: "true"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/local/photon/image-override-photon-local.yaml
+++ b/k8s/safe/kustomizations/local/photon/image-override-photon-local.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: localhost:5000/aegis-photon-safe:0.17.4
+          image: localhost:5000/aegis-photon-safe:0.18.0

--- a/k8s/safe/kustomizations/remote/istanbul-fips/Deployment.yaml
+++ b/k8s/safe/kustomizations/remote/istanbul-fips/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-safe
       containers:
         - name: main
-          image: aegishub/aegis-ist-safe:0.17.4
+          image: aegishub/aegis-ist-safe:0.18.0
           ports:
             - containerPort: 8443
           volumeMounts:
@@ -67,8 +67,8 @@ spec:
               value: "aegis-safe-age-key"
             - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
-            - name: AEGIS_MANUAL_KEY_INPUT
-              value: "true"
+            - name: AEGIS_SAFE_MANUAL_KEY_INPUT
+              value: "false"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/remote/istanbul-fips/Deployment.yaml
+++ b/k8s/safe/kustomizations/remote/istanbul-fips/Deployment.yaml
@@ -63,10 +63,12 @@ spec:
               value: "spiffe://aegis.ist/workload/aegis-safe/ns/aegis-system/sa/aegis-safe/n/"
             - name: AEGIS_SAFE_DATA_PATH
               value: "/data"
-            - name:  AEGIS_SAFE_AGE_KEY_SECRET_NAME
+            - name:  AEGIS_CRYPTO_KEY_NAME
               value: "aegis-safe-age-key"
-            - name: AEGIS_SAFE_AGE_KEY_PATH
+            - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
+            - name: AEGIS_MANUAL_KEY_INPUT
+              value: "true"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/remote/istanbul-fips/image-override-ist-fips-remote.yaml
+++ b/k8s/safe/kustomizations/remote/istanbul-fips/image-override-ist-fips-remote.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: aegishub/aegis-ist-fips-safe:0.17.4
+          image: aegishub/aegis-ist-fips-safe:0.18.0

--- a/k8s/safe/kustomizations/remote/istanbul/Deployment.yaml
+++ b/k8s/safe/kustomizations/remote/istanbul/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-safe
       containers:
         - name: main
-          image: aegishub/aegis-ist-safe:0.17.4
+          image: aegishub/aegis-ist-safe:0.18.0
           ports:
             - containerPort: 8443
           volumeMounts:
@@ -67,8 +67,8 @@ spec:
               value: "aegis-safe-age-key"
             - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
-            - name: AEGIS_MANUAL_KEY_INPUT
-              value: "true"
+            - name: AEGIS_SAFE_MANUAL_KEY_INPUT
+              value: "false"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/remote/istanbul/Deployment.yaml
+++ b/k8s/safe/kustomizations/remote/istanbul/Deployment.yaml
@@ -63,10 +63,12 @@ spec:
               value: "spiffe://aegis.ist/workload/aegis-safe/ns/aegis-system/sa/aegis-safe/n/"
             - name: AEGIS_SAFE_DATA_PATH
               value: "/data"
-            - name:  AEGIS_SAFE_AGE_KEY_SECRET_NAME
+            - name:  AEGIS_CRYPTO_KEY_NAME
               value: "aegis-safe-age-key"
-            - name: AEGIS_SAFE_AGE_KEY_PATH
+            - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
+            - name: AEGIS_MANUAL_KEY_INPUT
+              value: "true"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/remote/istanbul/image-override-ist-remote.yaml
+++ b/k8s/safe/kustomizations/remote/istanbul/image-override-ist-remote.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: aegishub/aegis-ist-safe:0.17.4
+          image: aegishub/aegis-ist-safe:0.18.0

--- a/k8s/safe/kustomizations/remote/photon-fips/Deployment.yaml
+++ b/k8s/safe/kustomizations/remote/photon-fips/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-safe
       containers:
         - name: main
-          image: aegishub/aegis-ist-safe:0.17.4
+          image: aegishub/aegis-ist-safe:0.18.0
           ports:
             - containerPort: 8443
           volumeMounts:
@@ -67,8 +67,8 @@ spec:
               value: "aegis-safe-age-key"
             - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
-            - name: AEGIS_MANUAL_KEY_INPUT
-              value: "true"
+            - name: AEGIS_SAFE_MANUAL_KEY_INPUT
+              value: "false"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/remote/photon-fips/Deployment.yaml
+++ b/k8s/safe/kustomizations/remote/photon-fips/Deployment.yaml
@@ -63,10 +63,12 @@ spec:
               value: "spiffe://aegis.ist/workload/aegis-safe/ns/aegis-system/sa/aegis-safe/n/"
             - name: AEGIS_SAFE_DATA_PATH
               value: "/data"
-            - name:  AEGIS_SAFE_AGE_KEY_SECRET_NAME
+            - name:  AEGIS_CRYPTO_KEY_NAME
               value: "aegis-safe-age-key"
-            - name: AEGIS_SAFE_AGE_KEY_PATH
+            - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
+            - name: AEGIS_MANUAL_KEY_INPUT
+              value: "true"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/remote/photon-fips/image-override-photon-fips-remote.yaml
+++ b/k8s/safe/kustomizations/remote/photon-fips/image-override-photon-fips-remote.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: aegishub/aegis-photon-fips-safe:0.17.4
+          image: aegishub/aegis-photon-fips-safe:0.18.0

--- a/k8s/safe/kustomizations/remote/photon/Deployment.yaml
+++ b/k8s/safe/kustomizations/remote/photon/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-safe
       containers:
         - name: main
-          image: aegishub/aegis-ist-safe:0.17.4
+          image: aegishub/aegis-ist-safe:0.18.0
           ports:
             - containerPort: 8443
           volumeMounts:
@@ -67,8 +67,8 @@ spec:
               value: "aegis-safe-age-key"
             - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
-            - name: AEGIS_MANUAL_KEY_INPUT
-              value: "true"
+            - name: AEGIS_SAFE_MANUAL_KEY_INPUT
+              value: "false"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/remote/photon/Deployment.yaml
+++ b/k8s/safe/kustomizations/remote/photon/Deployment.yaml
@@ -63,10 +63,12 @@ spec:
               value: "spiffe://aegis.ist/workload/aegis-safe/ns/aegis-system/sa/aegis-safe/n/"
             - name: AEGIS_SAFE_DATA_PATH
               value: "/data"
-            - name:  AEGIS_SAFE_AGE_KEY_SECRET_NAME
+            - name:  AEGIS_CRYPTO_KEY_NAME
               value: "aegis-safe-age-key"
-            - name: AEGIS_SAFE_AGE_KEY_PATH
+            - name: AEGIS_CRYPTO_KEY_PATH
               value: "/key/key.txt"
+            - name: AEGIS_MANUAL_KEY_INPUT
+              value: "true"
             - name: AEGIS_SAFE_SECRET_NAME_PREFIX
               value: "aegis-secret-"
             - name: AEGIS_PROBE_LIVENESS_PORT

--- a/k8s/safe/kustomizations/remote/photon/image-override-photon-remote.yaml
+++ b/k8s/safe/kustomizations/remote/photon/image-override-photon-remote.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: aegishub/aegis-photon-safe:0.17.4
+          image: aegishub/aegis-photon-safe:0.18.0

--- a/k8s/sentinel/kustomizations/local/istanbul-fips/Deployment.yaml
+++ b/k8s/sentinel/kustomizations/local/istanbul-fips/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-sentinel
       containers:
         - name: main
-          image: aegishub/aegis-ist-sentinel:0.17.4
+          image: aegishub/aegis-ist-sentinel:0.18.0
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/sentinel/kustomizations/local/istanbul-fips/image-override-ist-fips-local.yaml
+++ b/k8s/sentinel/kustomizations/local/istanbul-fips/image-override-ist-fips-local.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: localhost:5000/aegis-ist-fips-sentinel:0.17.4
+          image: localhost:5000/aegis-ist-fips-sentinel:0.18.0

--- a/k8s/sentinel/kustomizations/local/istanbul/Deployment.yaml
+++ b/k8s/sentinel/kustomizations/local/istanbul/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-sentinel
       containers:
         - name: main
-          image: aegishub/aegis-ist-sentinel:0.17.4
+          image: aegishub/aegis-ist-sentinel:0.18.0
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/sentinel/kustomizations/local/istanbul/image-override-ist-local.yaml
+++ b/k8s/sentinel/kustomizations/local/istanbul/image-override-ist-local.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: localhost:5000/aegis-ist-sentinel:0.17.4
+          image: localhost:5000/aegis-ist-sentinel:0.18.0

--- a/k8s/sentinel/kustomizations/local/photon-fips/Deployment.yaml
+++ b/k8s/sentinel/kustomizations/local/photon-fips/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-sentinel
       containers:
         - name: main
-          image: aegishub/aegis-ist-sentinel:0.17.4
+          image: aegishub/aegis-ist-sentinel:0.18.0
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/sentinel/kustomizations/local/photon-fips/image-override-photon-fips-local.yaml
+++ b/k8s/sentinel/kustomizations/local/photon-fips/image-override-photon-fips-local.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: localhost:5000/aegis-photon-fips-sentinel:0.17.4
+          image: localhost:5000/aegis-photon-fips-sentinel:0.18.0

--- a/k8s/sentinel/kustomizations/local/photon/Deployment.yaml
+++ b/k8s/sentinel/kustomizations/local/photon/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-sentinel
       containers:
         - name: main
-          image: aegishub/aegis-ist-sentinel:0.17.4
+          image: aegishub/aegis-ist-sentinel:0.18.0
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/sentinel/kustomizations/local/photon/image-override-photon-local.yaml
+++ b/k8s/sentinel/kustomizations/local/photon/image-override-photon-local.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: localhost:5000/aegis-photon-sentinel:0.17.4
+          image: localhost:5000/aegis-photon-sentinel:0.18.0

--- a/k8s/sentinel/kustomizations/remote/istanbul-fips/Deployment.yaml
+++ b/k8s/sentinel/kustomizations/remote/istanbul-fips/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-sentinel
       containers:
         - name: main
-          image: aegishub/aegis-ist-sentinel:0.17.4
+          image: aegishub/aegis-ist-sentinel:0.18.0
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/sentinel/kustomizations/remote/istanbul-fips/image-override-ist-fips-remote.yaml
+++ b/k8s/sentinel/kustomizations/remote/istanbul-fips/image-override-ist-fips-remote.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: aegishub/aegis-ist-fips-sentinel:0.17.4
+          image: aegishub/aegis-ist-fips-sentinel:0.18.0

--- a/k8s/sentinel/kustomizations/remote/istanbul/Deployment.yaml
+++ b/k8s/sentinel/kustomizations/remote/istanbul/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-sentinel
       containers:
         - name: main
-          image: aegishub/aegis-ist-sentinel:0.17.4
+          image: aegishub/aegis-ist-sentinel:0.18.0
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/sentinel/kustomizations/remote/istanbul/image-override-ist-remote.yaml
+++ b/k8s/sentinel/kustomizations/remote/istanbul/image-override-ist-remote.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: aegishub/aegis-ist-sentinel:0.17.4
+          image: aegishub/aegis-ist-sentinel:0.18.0

--- a/k8s/sentinel/kustomizations/remote/photon-fips/Deployment.yaml
+++ b/k8s/sentinel/kustomizations/remote/photon-fips/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-sentinel
       containers:
         - name: main
-          image: aegishub/aegis-ist-sentinel:0.17.4
+          image: aegishub/aegis-ist-sentinel:0.18.0
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/sentinel/kustomizations/remote/photon-fips/image-override-photon-fips-remote.yaml
+++ b/k8s/sentinel/kustomizations/remote/photon-fips/image-override-photon-fips-remote.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: aegishub/aegis-photon-fips-sentinel:0.17.4
+          image: aegishub/aegis-photon-fips-sentinel:0.18.0

--- a/k8s/sentinel/kustomizations/remote/photon/Deployment.yaml
+++ b/k8s/sentinel/kustomizations/remote/photon/Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aegis-sentinel
       containers:
         - name: main
-          image: aegishub/aegis-ist-sentinel:0.17.4
+          image: aegishub/aegis-ist-sentinel:0.18.0
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/sentinel/kustomizations/remote/photon/image-override-photon-remote.yaml
+++ b/k8s/sentinel/kustomizations/remote/photon/image-override-photon-remote.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: main
-          image: aegishub/aegis-photon-sentinel:0.17.4
+          image: aegishub/aegis-photon-sentinel:0.18.0


### PR DESCRIPTION
This pull request will enable manual initialization of Aegis Safe.

That way, you won’t need to store the master key in a Kubernetes secret.

That’s the good part.

But there’s no free lunch; you will be responsible for storing the master keys in a safe place like a cloud KMS.

This is the beginning of a series of features that will give more control over the usage of Aegis Safe.

So if you have a strict requirement of not using any Kubernetes Secrets at all, then you can configure Aegis Safe to do so, with minimal automation around where to store and how to inject the master keys.
